### PR TITLE
Change source for Markup app

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/appverifier/InternalVerificationInfoDatabase.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/appverifier/InternalVerificationInfoDatabase.kt
@@ -435,7 +435,7 @@ val internalVerificationInfoDatabase = setOf(
     InternalDatabaseVerificationInfo(
         "com.google.android.markup",
         listOf(
-            // Google Play Store
+            // Pixel OS
             Hashes(
                 listOf(
                     "BA:83:57:40:B0:89:8D:BB:0F:FD:CB:00:F5:3F:9C:90:D3:19:4B:64:C3:9A:55:88:47:8F:9A:1A:AD:79:14:4F",

--- a/app/src/main/kotlin/dev/soupslurpr/appverifier/InternalVerificationInfoDatabase.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/appverifier/InternalVerificationInfoDatabase.kt
@@ -435,7 +435,7 @@ val internalVerificationInfoDatabase = setOf(
     InternalDatabaseVerificationInfo(
         "com.google.android.markup",
         listOf(
-            // Pixel OS
+            // Google Pixel OS
             Hashes(
                 listOf(
                     "BA:83:57:40:B0:89:8D:BB:0F:FD:CB:00:F5:3F:9C:90:D3:19:4B:64:C3:9A:55:88:47:8F:9A:1A:AD:79:14:4F",


### PR DESCRIPTION
Changed source from Play Store to "Pixel OS". It is also mirrored in GrapheneOS' Apps app repository as well as many "APK sites", but the originating source of all of those is the app that's found in the stock Pixel OS, so it makes for that to be the source mentioned in the database.

To be clear, the cert I provided is for the app as downloaded from GrapheneOS' Apps app repository client, which should be the exact same as Stock OS.