### PR TITLE
Deleted repeated entry in InternalVerificationInfoDatabase.kt

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/appverifier/InternalVerificationInfoDatabase.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/appverifier/InternalVerificationInfoDatabase.kt
@@ -135,21 +135,6 @@ val internalVerificationInfoDatabase = setOf(
         )
     ),
     InternalDatabaseVerificationInfo(
-        "app.accrescent.client",
-        listOf(
-            Hashes(
-                listOf(
-                    Source.WEBSITE,
-                    Source.GITHUB
-                ),
-                listOf(
-                    "06:7A:40:C4:19:3A:AD:51:AC:87:F9:DD:FD:EB:B1:5E:24:A1:85:0B:AB:FA:48:21:C2:8C:5C:25:C3:FD:C0:71"
-                ),
-                false
-            )
-        )
-    ),
-    InternalDatabaseVerificationInfo(
         "net.mullvad.mullvadvpn",
         listOf(
             Hashes(


### PR DESCRIPTION
* Remove repeated entry for Accrescent store app
* Entry appears twice with the same SHA256 checksum
* Unless there's a reason why, I think repeated section should be deleted