### PR TITLE
Add Tor Browser

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/appverifier/InternalVerificationInfoDatabase.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/appverifier/InternalVerificationInfoDatabase.kt
@@ -1900,4 +1900,19 @@ val internalVerificationInfoDatabase = setOf(
             )
         )
     ),
+    InternalDatabaseVerificationInfo(
+        "org.torproject.torbrowser",
+        listOf(
+            Hashes(
+                listOf(
+                    Source.WEBSITE,
+                    Source.GOOGLE_PLAY_STORE
+                ),
+                listOf(
+                    "20:06:1F:04:5E:73:7C:67:37:5C:17:79:4C:FE:DB:43:6A:03:CE:C6:BA:CB:7C:B9:F9:66:42:20:5C:A2:CE:C8"
+                ),
+                false
+            )
+        )
+    ),
 )


### PR DESCRIPTION
https://www.torproject.org/

The website [says](https://support.torproject.org/tormobile/tormobile-7/) it's also available on F-Droid via [The Guardian Project's F-Droid repo](https://guardianproject.info/fdroid/) but I don't see it in that repo and it also isn't in the main F-Droid repo. Thus I've only added the other fingerprints.