### PR TITLE
Add Amex Deutschland

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/appverifier/InternalVerificationInfoDatabase.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/appverifier/InternalVerificationInfoDatabase.kt
@@ -1900,4 +1900,18 @@ val internalVerificationInfoDatabase = setOf(
             )
         )
     ),
+    InternalDatabaseVerificationInfo(
+        "com.americanexpress.android.acctsvcs.de",
+        listOf(
+            Hashes(
+                listOf(
+                    Source.GOOGLE_PLAY_STORE
+                ),
+                listOf(
+                    "DC:DA:0E:27:5E:04:C3:3A:04:06:8A:FF:EB:D4:03:ED:CF:A6:AE:B5:5D:F5:64:85:D5:4B:14:7E:B6:CF:1F:55"
+                ),
+                false
+            )
+        )
+    ),
 )


### PR DESCRIPTION
https://www.americanexpress.com/de-de/
https://www.americanexpress.com/de/kundenservice/digital/amex-deutschland.html

It only links to the Play Store via QR code. I kinda suspect that this might automatically redirect to the local version of the Amex app and not just the German one which this PR is about:
https://play.google.com/store/apps/details?id=com.americanexpress.android.acctsvcs.de