### PR TITLE
Don't clear UI state when opening app list

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/appverifier/AppVerifier.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/appverifier/AppVerifier.kt
@@ -167,7 +167,7 @@ fun AppVerifierApp(
                         verifyAppViewModel.setAppIcon(icon)
                         navController.navigate(AppVerifierScreens.VerifyApp.name)
                     },
-                    { verifyAppViewModel.clearUiState() },
+                    { },
                     { searchQuery = it },
                     { },
                     { },


### PR DESCRIPTION
This caused a bug where app details would disappear during the predictive back animation in the VerifyAppScreen

Before

https://github.com/user-attachments/assets/9258762e-6b77-4d5d-aa12-71911bf72b0e

After

https://github.com/user-attachments/assets/d663314d-bdc3-4f36-bc24-a9787bc2342e

