### PR TITLE
Removes duplicate Accrescent entry and adds an entry for the new Organic Maps internal application identifier

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/appverifier/InternalVerificationInfoDatabase.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/appverifier/InternalVerificationInfoDatabase.kt
@@ -136,21 +136,6 @@ val internalVerificationInfoDatabase = setOf(
         )
     ),
     InternalDatabaseVerificationInfo(
-        "app.accrescent.client",
-        listOf(
-            Hashes(
-                listOf(
-                    Source.WEBSITE,
-                    Source.GITHUB
-                ),
-                listOf(
-                    "06:7A:40:C4:19:3A:AD:51:AC:87:F9:DD:FD:EB:B1:5E:24:A1:85:0B:AB:FA:48:21:C2:8C:5C:25:C3:FD:C0:71"
-                ),
-                false
-            )
-        )
-    ),
-    InternalDatabaseVerificationInfo(
         "net.mullvad.mullvadvpn",
         listOf(
             Hashes(

--- a/app/src/main/kotlin/dev/soupslurpr/appverifier/InternalVerificationInfoDatabase.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/appverifier/InternalVerificationInfoDatabase.kt
@@ -1430,6 +1430,20 @@ val internalVerificationInfoDatabase = setOf(
         )
     ),
     InternalDatabaseVerificationInfo(
+        "app.organicmaps.web",
+        listOf(
+            Hashes(
+                listOf(
+                    Source.GITHUB
+                ),
+                listOf(
+                    "B9:C7:AE:79:A5:A9:02:70:DF:08:A1:32:E5:36:B9:C6:66:F5:BE:F1:F5:9B:30:4F:CE:CF:86:87:86:5E:4B:5B"
+                ),
+                false
+            )
+        )
+    ),
+    InternalDatabaseVerificationInfo(
         "com.noahjutz.gymroutines",
         listOf(
             Hashes(


### PR DESCRIPTION
Removes a duplicate entry for `app.accrescent.client` from the internal database.

Adds an entry for `app.organicmaps.web`, the identifier of the GitHub release of Organic Maps since the March 2024 update. The hash on this entry matches the hash on the original `app.organicmaps` client and the hash I found on the APK I downloaded from the current release.